### PR TITLE
fix: ensure smoke-tests exists with non-zero code on failure

### DIFF
--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -21,6 +21,7 @@ const URL_PARAM_VALUES = {
   notification_id: [],
   topic: Array.from({ length: 10 }).map(() => 'acme-inc.orders.1234'),
   device_token: ['x4doKe98yEZ21Kum2Qq39M3b8jkhonuIupobyFnL0wJMSWAZ8zoTp2dyHgV'],
+  import_id: [],
 };
 
 type Operation = {
@@ -172,7 +173,10 @@ function createTests(operations) {
     // should be able to deleteNotification({ id: createNotification().id }), but as the create action
     // is done through a job runner (sidekiq) the `delete` will be executed before the `create` is done.
     const shouldSkip =
-      operation.path.includes(':{') || operationId.startsWith('users-') || operationId === 'subscriptions-delete';
+      operation.path.includes(':{') ||
+      operationId.startsWith('users-') ||
+      operationId === 'subscriptions-delete' ||
+      operationId === 'imports-get';
 
     const code = getSuccessStatusCode(operation);
     list.add({
@@ -239,7 +243,7 @@ async function main() {
   await createTests(operations)
     .run()
     .catch(() => {
-      process.exit(0);
+      process.exit(1);
     });
 }
 


### PR DESCRIPTION
## Change description

Two small changes,

- Make sure that the smoke-test exits with non-zero code when it fails. It has proven itself valuable since we've implemented, and I believe it's now time to make it fail CI.

- Skip the "success test" for the imports route, as it depends on (async) input data managed via our job scheduler, which is something the automated smoke tests currently don't cover.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
