### PR TITLE
fix: document full response type for create notifications endpoint

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2387,7 +2387,7 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "title": { "type": "string", "description": "Overriden action_url" },
+          "title": { "type": "string", "description": "Title of the notification" },
           "recipients": {
             "description": "Recipients of the notification",
             "type": "array",
@@ -2422,7 +2422,17 @@
       "CreatedNotificationBroadcast": {
         "type": "object",
         "additionalProperties": false,
-        "properties": { "id": { "type": "string" } }
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "$ref": "#/components/schemas/Notification/properties/title" },
+          "content": { "$ref": "#/components/schemas/Notification/properties/content" },
+          "action_url": { "$ref": "#/components/schemas/Notification/properties/action_url" },
+          "category": { "$ref": "#/components/schemas/Notification/properties/category" },
+          "topic": { "$ref": "#/components/schemas/Notification/properties/topic" },
+          "custom_attributes": { "$ref": "#/components/schemas/Notification/properties/custom_attributes" },
+          "sent_at": { "type": "number" }
+        },
+        "required": ["id", "title", "sent_at"]
       },
       "Notifications": {
         "type": "object",


### PR DESCRIPTION
## Change description

The create notifications endpoint returns more than the notification.id alone. I've updated the related datatype to match the data that's being returned. I'm using pointers to keep the types in sync.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
