### PR TITLE
fix: declare phone_numbers as being a string array

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2045,6 +2045,9 @@
           "phone_numbers": {
             "type": "array",
             "description": "An array of phone numbers to use for sending SMS notifications.",
+            "items": {
+              "type": "string"
+            },
             "maxItems": 50
           }
         }


### PR DESCRIPTION
## Change description

Small fix, turns `phone_numbers` into a `string[]` instead of `unknown[]`.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
