### PR TITLE
fix: add app_bundle_id to push-subscriptions-create return type

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2485,7 +2485,8 @@
         "properties": {
           "id": { "type": "string" },
           "device_token": { "type": "string" },
-          "platform": { "type": "string" }
+          "platform": { "type": "string" },
+          "app_bundle_id": { "type": "string" }
         }
       },
       "PushSubscription": {


### PR DESCRIPTION
## Change description

Adds a missing field to `push-subscriptions-create` return type. It was present in the payload, but for some reason not mentioned in the response.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
