### PR TITLE
fix: add missing fields to notifications-list response

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2479,7 +2479,25 @@
           "notifications": {
             "type": "array",
             "description": "List of all notifications in the current page",
-            "items": { "$ref": "#/components/schemas/Notification" }
+            "items": { 
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "title": { "$ref": "#/components/schemas/Notification/properties/title" },
+                "content": { "$ref": "#/components/schemas/Notification/properties/content" },
+                "action_url": { "$ref": "#/components/schemas/Notification/properties/action_url" },
+                "category": { "$ref": "#/components/schemas/Notification/properties/category" },
+                "topic": { "$ref": "#/components/schemas/Notification/properties/topic" },
+                "custom_attributes": { "$ref": "#/components/schemas/Notification/properties/custom_attributes" },
+                "sent_at": { "type": "number" },
+                "seen_at": { "type": "number" },
+                "read_at": { "type": "number" },
+                "archived_at": { "type": "number" },
+                "recipient": { "$ref": "#/components/schemas/User" }
+              },
+              "required": ["id", "title", "sent_at"]
+             }
           }
         }
       },


### PR DESCRIPTION
## Change description

Fixes the `notifications-list` response by adding missing fields like `archived_at`, `read_at`,  `seen_at` and `sent_at`, and replaces the `recipients` array with the `recipient` object, as a notification (delivery) only has a single recipient.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
