### PR TITLE
GitHub discussions links

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -49,7 +49,8 @@ Time to explore the API
 
 ### Get Help
 
-- [Slack Community](https://join.slack.com/t/magicbell-community/shared_invite/zt-trh6yi84-~jtPqNikvC1m3My_p0WUqw)
+- If you are just starting, join our [GitHub Discussions](https://github.com/orgs/magicbell-io/discussions) to contribute, follow along, and get help from our active community.
+- If you are a power user, access our [Slack Community](https://join.slack.com/t/magicbell-community/shared_invite/zt-trh6yi84-~jtPqNikvC1m3My_p0WUqw) to brag about your integrations on top of powerful features like topics or Slack integrations. Let’s learn from each other!
 
 ## The MagicBell Way
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -50,7 +50,7 @@ Time to explore the API
 ### Get Help
 
 - If you are just starting, join our [GitHub Discussions](https://github.com/orgs/magicbell-io/discussions) to contribute, follow along, and get help from our active community.
-- If you are a power user, access our [Slack Community](https://join.slack.com/t/magicbell-community/shared_invite/zt-trh6yi84-~jtPqNikvC1m3My_p0WUqw) to brag about your integrations on top of powerful features like topics or Slack integrations. Let’s learn from each other!
+- If you are a power user, access our [Slack Community](https://magicbell.com/slack) to brag about your integrations on top of powerful features like topics or Slack integrations. Let’s learn from each other!
 
 ## The MagicBell Way
 

--- a/docs/docs/react/known-issues.mdx
+++ b/docs/docs/react/known-issues.mdx
@@ -28,5 +28,5 @@ export default function Index() {
 ## Support
 
 Please check our [GitHub Issue Tracker](https://github.com/magicbell-io/magicbell-react/issues) or
-[Slack Community](https://join.slack.com/t/magicbell-community/shared_invite/zt-trh6yi84-~jtPqNikvC1m3My_p0WUqw) if you're experiencing
+[GitHub Discussions](https://github.com/orgs/magicbell-io/discussions) if you're experiencing
 issues that are not listed on this page.

--- a/docs/sitemap.json
+++ b/docs/sitemap.json
@@ -342,8 +342,8 @@
     "staticRoute": true
   },
   {
-    "name": "Slack Community",
-    "to": "https://join.slack.com/t/magicbell-community/shared_invite/zt-trh6yi84-~jtPqNikvC1m3My_p0WUqw",
+    "name": "GitHub Discussions",
+    "to": "https://github.com/orgs/magicbell-io/discussions",
     "staticRoute": true
   },
   {

--- a/docs/src/components/menu/PageLink.tsx
+++ b/docs/src/components/menu/PageLink.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { ExternalLinkIcon } from '@heroicons/react/outline';
 
 interface Props {
   name: string | JSX.Element;
@@ -13,6 +14,13 @@ interface Props {
 export default function PageLink({ name, to, style }: Props) {
   const router = useRouter();
   const isActive = router.asPath === to;
+  const isInternalLink = !to || to.startsWith('/');
+  const aProps = isInternalLink
+    ? {}
+    : {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      };
 
   return (
     <Link href={to || ''}>
@@ -21,11 +29,13 @@ export default function PageLink({ name, to, style }: Props) {
           isActive
             ? 'bg-white text-lightPurple'
             : 'text-gray-600 hover:bg-white group-hover:text-gray-800',
-          'group py-3 px-6 flex items-center md:text-sm',
+          'group py-3 px-6 flex items-center md:text-sm justify-between',
         )}
         style={style}
+        {...aProps}
       >
-        {name}
+        <span>{name}</span>
+        {isInternalLink ? null : <ExternalLinkIcon className="h-4 w-4" />}
       </a>
     </Link>
   );


### PR DESCRIPTION
Single commits can be reviewed independently:
- `to` in `PageLink` is now required
- External links in left nav are marked with an icon (see image below)
- Links to Slack replaced with links to GH Discussions (at the org level)
- Explain that Slack is for power users

---

<img width="277" alt="Screenshot 2022-11-29 at 09 50 43" src="https://user-images.githubusercontent.com/5238698/204484901-fb2bf157-56e1-47ab-8ebb-9afc7dbcaf7e.png">