### PR TITLE
Docs: clarify recipients for notifications endpoint

### DIFF
--- a/docs/docs/sending-notifications.mdx
+++ b/docs/docs/sending-notifications.mdx
@@ -3,7 +3,7 @@ title: Sending Notifications
 subtitle: Learn how to send notifications using our API
 ---
 
-MagicBell allows you to send a notification to one user or many - up to 1000 users in a single request - using the [create notification API endpoint](/docs/rest-api/reference#operation/create-notification). The way you send notifications to a user depends on how you [identify users](/docs/choosing-an-identifier) in your app. MagicBell accepts emails and external IDs (strings) as unique identifiers for users.
+MagicBell allows you to send a notification to one user or many using the [create notification API endpoint](/docs/rest-api/reference#operation/create-notification). The way you send notifications to a user depends on how you [identify users](/docs/choosing-an-identifier) in your app. MagicBell accepts emails and external IDs (strings) as unique identifiers for users.
 
 We encourage you to run examples in your terminal as you read this guide. You can install curl by running:
 

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2158,7 +2158,7 @@
           "action_url": { "$ref": "#/components/schemas/Notification/properties/action_url" },
           "recipients": {
             "$ref": "#/components/schemas/Recipients",
-            "description": "Users to send the notification to. You can specify up to 1000 users at once. Use matches to send a notification to everyone.",
+            "description": "Users to send the notification to. You can specify up to 1000 users in the request body or use [matches](https://www.magicbell.com/docs/segments#how-to-create-segments-using-the-api) to send a notification to any number of users.",
             "nullable": false,
             "minItems": 1,
             "maxItems": 1000


### PR DESCRIPTION
The way it's phrased currently makes it seem that a notification can be sent to max 1.000 users.