### PR TITLE
fix: define type for NotificationPayload

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2184,6 +2184,7 @@
         "required": ["id", "title", "sent_at"]
       },
       "NotificationPayload": {
+        "type": "object",
         "additionalProperties": false,
         "properties": {
           "title": { "$ref": "#/components/schemas/Notification/properties/title" },


### PR DESCRIPTION
Specify `type` of `NotificationPayload`, to make it a valid json-schema and recognized by the docs parser.