### PR TITLE
fix: redirect idempotent-requests to section on overview page

### DIFF
--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -13,7 +13,12 @@
   },
   {
     "source": "/idempotent-requests",
-    "destination": "/rest-api/idempotent-requests",
+    "destination": "/rest-api/overview#idempotent-requests",
+    "permanent": true
+  },
+  {
+    "source": "/rest-api/idempotent-requests",
+    "destination": "/rest-api/overview#idempotent-requests",
     "permanent": true
   },
   {


### PR DESCRIPTION
## Change description

Redirect https://magicbell.com/docs/rest-api/idempotent-requests to https://magicbell.com/docs/rest-api/overview#idempotent-requests

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
