### PR TITLE
chore: add redirect for api-authentication page

### DIFF
--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -75,5 +75,10 @@
     "source": "/slack/block-api",
     "destination": "/slack/slack-provider-overrides",
     "permanent": true
+  },
+  {
+    "source": "/rest-api/authentication",
+    "destination": "/api-authentication",
+    "permanent": true
   }
 ]


### PR DESCRIPTION
Adds redirect to forward `https://www.magicbell.com/docs/rest-api/authentication` to `https://www.magicbell.com/docs/api-authentication`