### PR TITLE
design: api reference styling

### DIFF
--- a/docs/src/components/CollapsedSection.tsx
+++ b/docs/src/components/CollapsedSection.tsx
@@ -18,7 +18,7 @@ export default function CollapsedSection({ children, className, maxItems = 7 }: 
       {truncate ? take(maxItems, childrenArray).map((child) => child) : childrenArray}
       {truncate && (
         <button
-          className="block w-full p-2 bg-gray-100 text-darkPurple text-sm"
+          className="block w-full p-2 bg-bgDefault hover:bg-bgHover text-sm transition-colors"
           onClick={toggleCollapsed}
         >
           Show all

--- a/docs/src/components/graphql/Field.tsx
+++ b/docs/src/components/graphql/Field.tsx
@@ -24,11 +24,11 @@ export default function Field({ field, operation, schema }: Props) {
   const inputTypes = getGraphqlInputTypes(args);
 
   return (
-    <article id={href} className="py-36 border-t">
-      <h2 className="mt-0">
+    <article id={href} className="py-36 border-t mb-4">
+      <h2 className="mt-0 inline-block">
         <a href={`#${href}`}>{title}</a>
       </h2>
-      <p className="text-xs rounded bg-blue-50 px-3 py-2 text-blue-600 uppercase font-mono mb-4 inline-block">
+      <p className="text-xs rounded bg-blue-600 px-3 py-2 text-blue-50 uppercase font-mono inline-block relative bottom-1 ml-5">
         {operation.name}
       </p>
       <div className="flex space-x-0 xl:space-x-4 flex-wrap xl:flex-nowrap">
@@ -48,7 +48,7 @@ export default function Field({ field, operation, schema }: Props) {
                 <>
                   <span
                     className={
-                      'font-mono text-sm py-1 px-2 text-xs uppercase rounded-sm bg-violet-50 text-violet-600 mr-2'
+                      'font-mono text-sm py-1 px-2 text-xs uppercase rounded-sm bg-violet-600 text-violet-50 mr-2'
                     }
                   >
                     INPUT

--- a/docs/src/components/graphql/Field.tsx
+++ b/docs/src/components/graphql/Field.tsx
@@ -24,7 +24,7 @@ export default function Field({ field, operation, schema }: Props) {
   const inputTypes = getGraphqlInputTypes(args);
 
   return (
-    <article id={href} className="py-36 border-t mb-4">
+    <article id={href} className="py-24 border-t mb-4">
       <h2 className="mt-0 inline-block">
         <a href={`#${href}`}>{title}</a>
       </h2>

--- a/docs/src/components/graphql/FieldArguments.tsx
+++ b/docs/src/components/graphql/FieldArguments.tsx
@@ -16,7 +16,7 @@ export default function FieldArguments({ args, caption }: Props) {
       <p className={caption ? 'text-md' : 'text-sm uppercase'}>
         {caption || 'GraphQL Arguments'}
       </p>
-      <CollapsedSection className="border border-gray-200 rounded divide-y m-0">
+      <CollapsedSection className="border border-outlineDark rounded divide-y m-0">
         {args.map((argument, index) => (
           <InputArgument key={index} argument={argument} />
         ))}

--- a/docs/src/components/graphql/Headers.tsx
+++ b/docs/src/components/graphql/Headers.tsx
@@ -27,7 +27,7 @@ export default function Headers({ field }: Props) {
   return (
     <div className="mt-8 mb-12">
       <p className="uppercase text-sm">HTTP headers</p>
-      <ul className="border border-gray-200 rounded divide-y m-0">
+      <ul className="border border-outlineDark rounded divide-y m-0">
         {requestHeaders.map((header, index) => (
           // @ts-ignore
           <Parameter key={index} param={header} />

--- a/docs/src/components/graphql/InputArgument.tsx
+++ b/docs/src/components/graphql/InputArgument.tsx
@@ -19,7 +19,9 @@ export default function InputArgument({ argument }: Props) {
 
   return (
     <li className="list-none p-2">
-      <p className="font-mono flex items-center mb-0.5">{name}</p>
+      <p className="font-mono flex items-center mb-0.5">
+        <span className="bg-bgDefault text-highlight p-1 rounded">{name}</span>
+      </p>
       {description && (
         <p
           className="opacity-80 m-0"
@@ -28,7 +30,7 @@ export default function InputArgument({ argument }: Props) {
           }}
         />
       )}
-      <p className="opacity-80 m-0 capitalize">
+      <p className="opacity-80 m-0 mt-2 capitalize caption text-muted">
         {isInputType ? <a href={`#${getLink(type)}`}>{typeName}</a> : typeName}
       </p>
     </li>

--- a/docs/src/components/graphql/InputArgument.tsx
+++ b/docs/src/components/graphql/InputArgument.tsx
@@ -2,6 +2,7 @@ import { GraphQLArgument, GraphQLNonNull } from 'graphql';
 import React from 'react';
 import { isGraphqlInputObjectType } from './lib';
 import { getLink } from './link';
+import { Tag } from '@darkmagic/react'
 
 interface Props {
   argument: GraphQLArgument;
@@ -30,9 +31,9 @@ export default function InputArgument({ argument }: Props) {
           }}
         />
       )}
-      <p className="opacity-80 m-0 mt-2 capitalize caption text-muted">
+      <Tag className="mt-2">
         {isInputType ? <a href={`#${getLink(type)}`}>{typeName}</a> : typeName}
-      </p>
+      </Tag>
     </li>
   );
 }

--- a/docs/src/components/graphql/InputArgument.tsx
+++ b/docs/src/components/graphql/InputArgument.tsx
@@ -2,7 +2,7 @@ import { GraphQLArgument, GraphQLNonNull } from 'graphql';
 import React from 'react';
 import { isGraphqlInputObjectType } from './lib';
 import { getLink } from './link';
-import { Tag } from '@darkmagic/react'
+import { Tag } from '@darkmagic/react';
 
 interface Props {
   argument: GraphQLArgument;

--- a/docs/src/components/graphql/Type.tsx
+++ b/docs/src/components/graphql/Type.tsx
@@ -24,7 +24,7 @@ export function Type({ type }: TypeProps) {
   }`;
 
   return (
-    <article id={href} className="py-36 border-t">
+    <article id={href} className="py-24 border-t">
       <h2 className="mt-0 inline-block">
         <a href={`#${href}`}>{type.name}</a>
       </h2>

--- a/docs/src/components/graphql/Type.tsx
+++ b/docs/src/components/graphql/Type.tsx
@@ -25,10 +25,10 @@ export function Type({ type }: TypeProps) {
 
   return (
     <article id={href} className="py-36 border-t">
-      <h2 className="mt-0">
+      <h2 className="mt-0 inline-block">
         <a href={`#${href}`}>{type.name}</a>
       </h2>
-      <p className="text-xs rounded bg-blue-50 px-3 py-2 text-blue-600 uppercase font-mono mb-4 inline-block">
+      <p className="text-xs rounded bg-blue-600 px-3 py-2 text-blue-50 uppercase font-mono mb-4 inline-block relative bottom-1 ml-5">
         {objectType}
       </p>
       <div className="flex space-x-0 xl:space-x-4 flex-wrap xl:flex-nowrap">

--- a/docs/src/components/openapi/HeaderParameters.tsx
+++ b/docs/src/components/openapi/HeaderParameters.tsx
@@ -16,8 +16,8 @@ export default function HeaderParameters({ parameteres = [] }: Props) {
   if (!headerParams.length) return null;
   return (
     <div className="mt-8 mb-12">
-      <p className="uppercase text-sm">HTTP headers</p>
-      <ul className="border border-gray-200 rounded divide-y m-0">
+      <p className="uppercase">HTTP headers</p>
+      <ul className="border border-outlineDark rounded divide-y m-0">
         {headerParams.map((param, index) => (
           <Parameter key={index} param={param} />
         ))}

--- a/docs/src/components/openapi/Operation.tsx
+++ b/docs/src/components/openapi/Operation.tsx
@@ -22,11 +22,11 @@ export default function Operation({ pathKey, operation, method }: Props) {
 
   return (
     <article id={operation.operationId} className="py-36 border-t">
-      <h2 className="mt-0" id={href}>
+      <h2 className="mt-0 mb-10 inline-block" id={href}>
         <a href={`#${href}`}>{operation.summary}</a>
       </h2>
       {realTimeEnabled ? (
-        <p className="text-xs rounded bg-blue-50 px-3 py-2 text-blue-600 uppercase font-mono mb-4 inline-block">
+        <p className="text-xs rounded bg-blue-600 px-3 py-2 text-blue-50 uppercase font-mono inline-block ml-5 relative bottom-1">
           real-time
         </p>
       ) : null}

--- a/docs/src/components/openapi/Operation.tsx
+++ b/docs/src/components/openapi/Operation.tsx
@@ -21,7 +21,7 @@ export default function Operation({ pathKey, operation, method }: Props) {
   const href = getLink(operation.summary || '');
 
   return (
-    <article id={operation.operationId} className="py-36 border-t">
+    <article id={operation.operationId} className="py-24 first:pt-12">
       <h2 className="mt-0 mb-10 inline-block" id={href}>
         <a href={`#${href}`}>{operation.summary}</a>
       </h2>

--- a/docs/src/components/openapi/Parameter.tsx
+++ b/docs/src/components/openapi/Parameter.tsx
@@ -10,7 +10,7 @@ export default function Parameter({ param }: Props) {
   return (
     <li className="list-none p-2">
       <p className="font-mono flex items-center mb-0.5">
-        {param.name}
+        <span className="bg-bgDefault text-highlight p-1 rounded">{param.name}</span>
         {param.required && <span className="text-red-500 mx-4 text-xs">required</span>}
       </p>
       <p
@@ -19,7 +19,7 @@ export default function Parameter({ param }: Props) {
           __html: param.description?.replace(/\n/g, '<br/>') || '',
         }}
       />
-      <p className="opacity-80 m-0 capitalize">
+      <p className="opacity-80 m-0 mt-2 capitalize caption text-muted">
         {/* @ts-ignore */}
         {param.schema?.type}
       </p>

--- a/docs/src/components/openapi/Parameter.tsx
+++ b/docs/src/components/openapi/Parameter.tsx
@@ -1,5 +1,6 @@
 import { OpenAPIV3 } from 'openapi-types';
 import React from 'react';
+import { Tag } from '@darkmagic/react';
 
 interface Props {
   param?: OpenAPIV3.ParameterObject;
@@ -11,7 +12,7 @@ export default function Parameter({ param }: Props) {
     <li className="list-none p-2">
       <p className="font-mono flex items-center mb-0.5">
         <span className="bg-bgDefault text-highlight p-1 rounded">{param.name}</span>
-        {param.required && <span className="text-red-500 mx-4 text-xs">required</span>}
+        {param.required && <span className="text-error mx-4 text-xs">Required</span>}
       </p>
       <p
         className="opacity-80 m-0"
@@ -19,10 +20,10 @@ export default function Parameter({ param }: Props) {
           __html: param.description?.replace(/\n/g, '<br/>') || '',
         }}
       />
-      <p className="opacity-80 m-0 mt-2 capitalize caption text-muted">
+      <Tag css={{ mt: '8px' }}>
         {/* @ts-ignore */}
         {param.schema?.type}
-      </p>
+      </Tag>
     </li>
   );
 }

--- a/docs/src/components/openapi/QueryParameters.tsx
+++ b/docs/src/components/openapi/QueryParameters.tsx
@@ -16,8 +16,8 @@ export default function QueryParameters({ parameteres = [] }: Props) {
   if (!params.length) return null;
   return (
     <div className="mt-8 mb-12">
-      <p className="uppercase text-sm">Query parameters</p>
-      <ul className="border border-gray-200 rounded divide-y m-0">
+      <p className="uppercase">Query parameters</p>
+      <ul className="border border-outlineDark rounded divide-y m-0">
         {params.map((param, index) => (
           <Parameter key={index} param={param} />
         ))}

--- a/docs/src/components/openapi/RequestBody.tsx
+++ b/docs/src/components/openapi/RequestBody.tsx
@@ -19,8 +19,8 @@ export default function RequestBody({ requestBody }: Props) {
   if (!schemaProperties) return null;
   return (
     <div className="mt-8 mb-12 overflow-hidden">
-      <p className="uppercase text-sm">Body Parameters</p>
-      <ul className="border border-gray-200 rounded divide-y m-0">
+      <p className="uppercase">Body Parameters</p>
+      <ul className="border border-outlineDark rounded divide-y m-0">
         {Object.keys(schemaProperties).map((propertyName, index) => (
           <SchemaObject
             key={index}

--- a/docs/src/components/openapi/SchemaObject.tsx
+++ b/docs/src/components/openapi/SchemaObject.tsx
@@ -36,25 +36,29 @@ export default function SchemaObject({
   return (
     <div className="p-2">
       <p className="font-mono white break-all mb-0.5">
-        {objectParents.length > 0 ? (
-          <span className="opacity-60">{objectParents.join('.') + '.'}</span>
-        ) : null}
-        <span>{propertyName}</span>
+        <span className="bg-bgDefault rounded p-1">
+          {objectParents.length > 0 ? <>{objectParents.join('.') + '.'}</> : null}
+          <span className="text-highlight">{propertyName}</span>
+        </span>
         {required && <span className="text-red-500 mx-4 text-xs">required</span>}
       </p>
       <p className="m-0 opacity-80">{object.description}</p>
-      <p className="mb-0 opacity-80 capitalize mt-2">{object.type}</p>
+      <p className="mb-0 opacity-80 capitalize mt-2 text-muted caption">{object.type}</p>
       {object.maxLength ? (
-        <p className="mb-0 opacity-80">Max length: {object.maxLength}</p>
+        <p className="mb-0 opacity-80 text-muted caption">
+          Max length: {object.maxLength}
+        </p>
       ) : null}
       {object.minLength ? (
-        <p className="mb-0 opacity-80">Min length: {object.minLength}</p>
+        <p className="mb-0 opacity-80 text-muted caption">
+          Min length: {object.minLength}
+        </p>
       ) : null}
       {object.maxItems ? (
-        <p className="mb-0 opacity-80">Max items: {object.maxItems}</p>
+        <p className="mb-0 opacity-80 text-muted caption">Max items: {object.maxItems}</p>
       ) : null}
       {object.minItems ? (
-        <p className="mb-0 opacity-80">Min items: {object.minItems}</p>
+        <p className="mb-0 opacity-80 text-muted caption">Min items: {object.minItems}</p>
       ) : null}
     </div>
   );

--- a/docs/src/components/openapi/SchemaObject.tsx
+++ b/docs/src/components/openapi/SchemaObject.tsx
@@ -2,6 +2,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { includes, init, last } from 'ramda';
 import React from 'react';
 import CollapsedSection from '../CollapsedSection';
+import { Tag } from '@darkmagic/react';
 
 interface Props {
   object?: OpenAPIV3.SchemaObject;
@@ -34,31 +35,27 @@ export default function SchemaObject({
   const objectParents = init(objectPathAcc);
   const propertyName = last(objectPathAcc);
   return (
-    <div className="p-2">
+    <div className="p-3">
       <p className="font-mono white break-all mb-0.5">
         <span className="bg-bgDefault rounded p-1">
           {objectParents.length > 0 ? <>{objectParents.join('.') + '.'}</> : null}
           <span className="text-highlight">{propertyName}</span>
         </span>
-        {required && <span className="text-red-500 mx-4 text-xs">required</span>}
+        {required && <span className="text-error mx-4 text-xs">Required</span>}
       </p>
       <p className="m-0 opacity-80">{object.description}</p>
-      <p className="mb-0 opacity-80 capitalize mt-2 text-muted caption">{object.type}</p>
+      <Tag css={{ mt: '8px' }}>{object.type}</Tag>
       {object.maxLength ? (
-        <p className="mb-0 opacity-80 text-muted caption">
-          Max length: {object.maxLength}
-        </p>
+        <Tag css={{ mt: '8px', ml: '6px' }}>Max length: {object.maxLength}</Tag>
       ) : null}
       {object.minLength ? (
-        <p className="mb-0 opacity-80 text-muted caption">
-          Min length: {object.minLength}
-        </p>
+        <Tag css={{ mt: '8px', ml: '6px' }}>Min length: {object.minLength}</Tag>
       ) : null}
       {object.maxItems ? (
-        <p className="mb-0 opacity-80 text-muted caption">Max items: {object.maxItems}</p>
+        <Tag css={{ mt: '8px', ml: '6px' }}>Max items: {object.maxItems}</Tag>
       ) : null}
       {object.minItems ? (
-        <p className="mb-0 opacity-80 text-muted caption">Min items: {object.minItems}</p>
+        <Tag css={{ mt: '8px', ml: '6px' }}>Min items: {object.minItems}</Tag>
       ) : null}
     </div>
   );

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -37,7 +37,7 @@ img::selection {
 @tailwind base;
 @layer base {
   * {
-    box-sizing: border-box;
+    @apply border-outlineDark box-border;
   }
 
   body,
@@ -191,4 +191,8 @@ h3 a {
 h2 a:hover,
 h3 a:hover {
   @apply text-hover;
+}
+
+.caption {
+  @apply font-semibold text-sm;
 }

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
         link: '#9E8CFC',
         hover: '#BCAFFD',
         highlight: '#FFEF5C',
+        error: ' #F16A50',
 
         // Gradient
         yellowOutlineStart: '#FFB224BF',

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
         muted: '#A09FA6',
         link: '#9E8CFC',
         hover: '#BCAFFD',
+        highlight: '#FFEF5C',
 
         // Gradient
         yellowOutlineStart: '#FFB224BF',
@@ -28,6 +29,8 @@ module.exports = {
         // Base
         app: '#1B1D29',
         app2: '#1E212F',
+        bgDefault: '#23283B',
+        bgHover: '#21283E',
         outlineDark: '#3F3566',
         darkGradientStart: '#23283d40',
         darkGradientEnd: '#1e212f0d',


### PR DESCRIPTION
## Change description

Improved design of API tables according to DarkMagic theme: 
- Dimmed table borders
- Changed label text colors
- Fixed Padding
- Changed `Read more` button to follow DarkMagic

## Before:

<img width="1552" alt="Screenshot 2023-03-03 at 4 23 28 PM" src="https://user-images.githubusercontent.com/36479718/222702339-fffda1e3-eb70-49fd-9cdf-8ce3b1de0a7a.png">

## After:
<img width="2160" alt="Screenshot 2023-03-24 at 4 15 58 PM" src="https://user-images.githubusercontent.com/36479718/227500956-110e161f-c857-4939-b07a-aab1708dab65.png">

<img width="2160" alt="Screenshot 2023-03-24 at 4 16 24 PM" src="https://user-images.githubusercontent.com/36479718/227501052-dbf0979f-3843-4cf5-973d-16d007236758.png">

## Type of change

- [ ] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
