### PR TITLE
fix: make heading size dynamic, fix mobile nav

### DIFF
--- a/docs/src/components/layout/Content.tsx
+++ b/docs/src/components/layout/Content.tsx
@@ -9,7 +9,7 @@ export default function Content({ children }: Props) {
   return (
     <div className="flex-1 pb-24 overflow-x-hidden w-full md:px-8">
       <div className="flex flex-col">
-        <div className="md:mt-4 md:py-4 px-4 md:px-0">
+        <div className="md:mt-4 py-4 px-4 md:px-0">
           <SearchBar />
         </div>
         <main className="flex-1 relative overflow-y-auto focus:outline-none px-4 md:px-0">

--- a/docs/src/components/layout/Header.tsx
+++ b/docs/src/components/layout/Header.tsx
@@ -68,7 +68,7 @@ export default function Header({ onToggleMenu }: Props) {
       <div className="flex-1 flex items-center md:hidden px-4 py-6">
         <a href="https://www.magicbell.com">
           <MagicBellLogo
-            className="h-7 fill-current text-darkPurple"
+            className="h-7 fill-current text-default"
             role="img"
             aria-label="MagicBell logo"
             focusable="false"
@@ -76,7 +76,7 @@ export default function Header({ onToggleMenu }: Props) {
         </a>
       </div>
       <button
-        className="p-4 focus:outline-none md:hidden text-darkPurple"
+        className="p-4 focus:outline-none md:hidden text-default"
         onClick={toggleMenu}
       >
         <span className="sr-only">Open main menu</span>

--- a/docs/src/components/menu/MobileMenu.tsx
+++ b/docs/src/components/menu/MobileMenu.tsx
@@ -41,7 +41,7 @@ export default function MobileMenu({
           <div className="mt-12 flex flex-col overflow-scroll">
             <Menu navigationItems={navigationItems} openAPILinks={openAPILinks} />
             <a
-              className="m-6 mobile-signup-button text-center"
+              className="m-6 text-center rounded-md py-3 px-6 font-bold text-black bg-yellow hover:text-black hover:bg-lightYellow transition-colors"
               href="https://app.magicbell.com"
             >
               Sign Up

--- a/docs/src/components/menu/MobileMenu.tsx
+++ b/docs/src/components/menu/MobileMenu.tsx
@@ -30,11 +30,11 @@ export default function MobileMenu({
             visible: { x: 0 },
           }}
           transition={{ duration: 0.35, stiffness: 0 }}
-          className="fixed h-screen top-0 bottom-0 flex-1 flex flex-col max-w-xs w-full z-50 shadow"
+          className="fixed h-screen top-0 bottom-0 flex-1 flex flex-col max-w-xs w-full z-50 shadow bg-app"
         >
           <button
             onClick={toggle}
-            className="absolute top-0 right-0 p-4 text-gray-400 hover:text-gray-800"
+            className="absolute top-0 right-0 p-4 text-gray-400 hover:text-default"
           >
             <XIcon className="h-6 w-6" />
           </button>

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -157,12 +157,6 @@ header {
   font-size: 20px;
 }
 
-a.mobile-signup-button {
-  background-color: #230f65 !important;
-  color: white !important;
-  @apply rounded-md py-3 px-6 font-bold;
-}
-
 /* Footer */
 footer a {
   @apply text-default hover:text-hover;

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -50,7 +50,8 @@ img::selection {
   }
 
   h1 {
-    @apply text-6xl mb-14 font-semibold text-default font-heading;
+    @apply mb-14 font-semibold text-default font-heading;
+    font-size: clamp(2rem, 8vw - 1.5rem, 3.5rem);
   }
 
   h2 {


### PR DESCRIPTION
## Change description

- H1 `font-size` doesn't look good on mobile.
- The MagicBell logo and hamburger icon on mobile nav wasn't visible.
- Some other minor nav bar improvements.

Before                                  |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/36479718/225724707-b0800c19-6526-4482-a765-14ba2bb9f7d8.png) |  ![image](https://user-images.githubusercontent.com/36479718/225916749-03cbe8b9-2cba-43cb-96d0-54a0538bb391.png)




> Description here

## Type of change

- [ ] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
