### PR TITLE
chore: rename push-subscriptions-get to push-subscriptions-list

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -1296,7 +1296,7 @@
         "tags": ["User's Push Subscriptions APIs"],
         "summary": "Fetch user's push subscriptions",
         "description": "Fetch a user's push subscriptions. Returns a paginated list of web and mobile push subscriptions for all platforms.",
-        "operationId": "users-push-subscriptions-get",
+        "operationId": "users-push-subscriptions-list",
         "responses": {
           "200": {
             "description": "OK",


### PR DESCRIPTION
## Change description

Rename operation-id to list (paginated) instead of get (one)

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
