### PR TITLE
spec: allow null for delivery title

### DIFF
--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2788,7 +2788,7 @@
         "required": ["id", "title", "channel", "scheduled_at", "status"],
         "properties": {
           "id": { "type": "string", "nullable": false },
-          "title": { "type":  "string", "nullable": false },
+          "title": { "type":  "string", "nullable": true },
           "channel": { "type": "string", "nullable": false },
           "scheduled_at": { "type": "string", "format": "date-time" },
           "status": {


### PR DESCRIPTION
## Change description

Title can be `null` when the delivery hasn't seen the template parser yet.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
