### PR TITLE
fix: ensure cache is based on monorepo root

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,10 +8,6 @@ inputs:
     required: false
     default: "18.x"
 
-  working-directory:
-    description: "working directory"
-    required: true
-
 runs:
   using: "composite"
   steps:
@@ -24,10 +20,10 @@ runs:
       id: cache
       uses: actions/cache@v2
       with:
-        path: ${{ inputs.working-directory }}/node_modules
+        path: node_modules
         key: ${{ runner.os }}-${{ runner.arch }}-node_modules-${{ hashFiles('yarn.lock') }}
 
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: yarn --cwd ${{ inputs.working-directory }} --frozen-lockfile
+      run: yarn --frozen-lockfile

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Node
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: .
 
       - name: Create release PR or publish release
         uses: changesets/action@v1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Node
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: docs
       - name: Run unit tests
-        run: yarn  --cwd ./docs test
+        run: yarn --cwd ./docs test

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,10 +1,6 @@
 name: openapi
 on: [push]
 
-defaults:
-  run:
-    working-directory: openapi
-
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -13,8 +9,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: setup node
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: openapi
       - name: validate openapi spec
         run: yarn --cwd ./openapi validate
   smoke-test:
@@ -25,8 +19,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: setup node
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: openapi
       - name: smoke test
         uses: ./.github/actions/smoke-test
         env:


### PR DESCRIPTION
## Change description

Change cache paths to be based on monorepo root, as we now have a single yarn.lock

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
