### PR TITLE
spec: remove `total` and `total_pages` props from paginated responses

### DIFF
--- a/.changeset/forty-jeans-cough.md
+++ b/.changeset/forty-jeans-cough.md
@@ -1,0 +1,9 @@
+---
+"openapi": minor
+---
+
+Remove the `total` and `total_pages` properties from the response of the following requests:
+
+- `GET /broadcasts`.
+- `GET /broadcasts/{broadcast-id}/notifications`.
+- `GET /users`.

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -842,7 +842,21 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PaginatedUsers" },
+                "schema": {
+                  "allOf": [
+                    { "$ref":  "#/components/schemas/PaginationProps" },
+                    {
+                      "type": "object",
+                      "required": ["user"],
+                      "properties": {
+                        "user": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/User" }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "example": {
                   "current_page": "1",
                   "total_pages": "1",
@@ -3250,21 +3264,11 @@
       },
       "PaginationProps": {
         "type": "object",
-        "required": ["total", "per_page", "total_pages", "current_page"],
+        "required": ["per_page", "current_page"],
         "properties": {
-          "total": {
-            "type": "integer",
-            "description": "Total number of entities for this query.",
-            "readOnly": true
-          },
           "per_page": {
             "type": "integer",
             "description": "Number of entities per page.",
-            "readOnly": true
-          },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages.",
             "readOnly": true
           },
           "current_page": {


### PR DESCRIPTION
## Change description

Remove the `total` and `total_pages` properties from the response of the following requests:

- `GET /broadcasts`.
- `GET /broadcasts/{broadcast-id}/notifications`.
- `GET /users`.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
