### PR TITLE
feat: add workflow to automatically update postman collections

### DIFF
--- a/.github/workflows/update-postman-collection.yml
+++ b/.github/workflows/update-postman-collection.yml
@@ -44,9 +44,9 @@ jobs:
 
       # Files Generated during the intermediate steps of converting OpenAPI spec to body for Postman API are stored as artifacts
       # These files can be useful for debugging
-      # - uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: Generated Files
-      #     path: openapi/spec
-      #     retention-days: 10
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Generated Files
+          path: openapi/spec
+          retention-days: 10

--- a/.github/workflows/update-postman-collection.yml
+++ b/.github/workflows/update-postman-collection.yml
@@ -1,10 +1,13 @@
 name: Update Postman Collection
 
-# TODO: Change to on each PR after development
 on:
   push:
     branches-ignore:
       - main
+
+# TODO: change the postman collection ID after testing
+env:
+  POSTMAN_COLLECTION_ID: 27196362-488c1fbf-138e-475b-8e01-46df1b1a60d8
 
 jobs:
   postman:
@@ -33,10 +36,18 @@ jobs:
       - name: Add Postman Spec to a collection object
         run: "cd openapi/spec && jq '{collection: .}' postman-spec.json > postman-spec-in-collection-obj.json"
 
-        # TODO: Update the `collection ID` after testing workflow
       - name: Update the Postman Collection
         run: |
-          curl --location --request PUT 'https://api.getpostman.com/collections/27196362-0e2da69d-5bcf-4c00-89c1-7daa92e87516' \
+          curl --location --request PUT 'https://api.getpostman.com/collections/${{ env.POSTMAN_COLLECTION_ID }}' \
           --header 'Content-Type: application/json' \
           --header 'X-API-Key: ${{ secrets.POSTMAN_API_KEY }}' \
           --data '@openapi/spec/postman-spec-in-collection-obj.json'
+
+      # Files Generated during the intermediate steps of converting OpenAPI spec to body for Postman API are stored as artifacts
+      # These files can be useful for debugging
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: Generated Files
+      #     path: openapi/spec
+      #     retention-days: 10

--- a/.github/workflows/update-postman-collection.yml
+++ b/.github/workflows/update-postman-collection.yml
@@ -1,0 +1,41 @@
+name: Update Postman Collection
+
+# TODO: Change to on each PR after development
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  postman:
+    name: Postman Collection Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install curl and jq
+        run: sudo apt-get update && sudo apt-get install -y curl jq
+
+      - name: Install openapi-to-postman tool
+        run: npm i -g openapi-to-postmanv2
+
+      - name: Convert openapi spec to Postman Spec
+        run: "cd openapi/spec && openapi2postmanv2 -s openapi.json -o postman-spec.json -p"
+
+        # The Postman API for updating a collection requires the postman spec to be in a collection object
+        # This command uses jq to add the postman spec to a collection object and outputs that to `postman-spec-in-collection-obj.json` file
+      - name: Add Postman Spec to a collection object
+        run: "cd openapi/spec && jq '{collection: .}' postman-spec.json > postman-spec-in-collection-obj.json"
+
+      - name: Update the Postman Collection
+        run: |
+          curl --location --request PUT 'https://api.getpostman.com/collections/27196362-0e2da69d-5bcf-4c00-89c1-7daa92e87516' \
+          --header 'Content-Type: application/json' \
+          --header 'X-API-Key: ${{ secrets.POSTMAN_API_KEY }}}' \
+          --data '@openapi/spec/postman-spec-in-collection-obj.json'

--- a/.github/workflows/update-postman-collection.yml
+++ b/.github/workflows/update-postman-collection.yml
@@ -2,12 +2,11 @@ name: Update Postman Collection
 
 on:
   push:
-    branches-ignore:
+    branches:
       - main
 
-# TODO: change the postman collection ID after testing
 env:
-  POSTMAN_COLLECTION_ID: 27196362-488c1fbf-138e-475b-8e01-46df1b1a60d8
+  POSTMAN_COLLECTION_ID: 2269098-9f990075-94a8-4ded-b252-a5289b6e3a2f
 
 jobs:
   postman:

--- a/.github/workflows/update-postman-collection.yml
+++ b/.github/workflows/update-postman-collection.yml
@@ -33,9 +33,10 @@ jobs:
       - name: Add Postman Spec to a collection object
         run: "cd openapi/spec && jq '{collection: .}' postman-spec.json > postman-spec-in-collection-obj.json"
 
+        # TODO: Update the `collection ID` after testing workflow
       - name: Update the Postman Collection
         run: |
           curl --location --request PUT 'https://api.getpostman.com/collections/27196362-0e2da69d-5bcf-4c00-89c1-7daa92e87516' \
           --header 'Content-Type: application/json' \
-          --header 'X-API-Key: ${{ secrets.POSTMAN_API_KEY }}}' \
+          --header 'X-API-Key: ${{ secrets.POSTMAN_API_KEY }}' \
           --data '@openapi/spec/postman-spec-in-collection-obj.json'


### PR DESCRIPTION
## Change description
This PR adds a workflow that will automatically update our Postman collections when new commits are added to the main branch. 

### Workflow

We have an [OpenAPI v3.0 specification json file](https://github.com/magicbell-io/public/blob/main/openapi/spec/openapi.json) in this repository.

1. The OpenAPI Spec is converted to a Postman Collection (v2) format with [OpenAPI to Postman CLI ](https://github.com/postmanlabs/openapi-to-postman#-command-line-interface)

2. The Postman Collection Format is JSON. The JSON object is added as a value to the `collection` property with [jq](https://github.com/stedolan/jq).
The [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a?entity=request-12959542-bc8b292b-ffbb-4c67-a2a1-2fc416e2aef8&branch=&version=) expects a `collection` object to contain the postman collection format.

3. curl is used to send a PUT request to the Postman API that updates our Postman collection.


## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
