### PR TITLE
spec: remove beta flag from broadcasts endpoints

### DIFF
--- a/.changeset/lazy-kings-shave.md
+++ b/.changeset/lazy-kings-shave.md
@@ -1,0 +1,9 @@
+---
+"openapi": minor
+---
+
+Remove the beta flags from the broadcasts apis. This includes:
+
+- `GET /broadcasts`
+- `GET /broadcasts/{broadcast_id}`
+- `GET /broadcasts/{broadcast_id}/notifications`

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -10,7 +10,6 @@
   "paths": {
     "/broadcasts": {
       "get": {
-        "x-beta": true,
         "tags": ["Notification Broadcasts APIs"],
         "operationId": "broadcasts-list",
         "summary": "List notification broadcasts",
@@ -49,7 +48,6 @@
     },
     "/broadcasts/{broadcast_id}": {
       "get": {
-        "x-beta": true,
         "tags": ["Notification Broadcasts APIs"],
         "operationId": "broadcasts-get",
         "summary": "Fetch a notification broadcast by its ID",
@@ -81,7 +79,6 @@
     },
     "/broadcasts/{broadcast_id}/notifications": {
       "get": {
-        "x-beta": true,
         "tags": ["Notification Broadcasts APIs"],
         "operationId": "broadcasts-notifications-list",
         "summary": "Fetch notifications by broadcast id.",


### PR DESCRIPTION
## Change description

Remove the beta flags from the broadcasts apis. This includes:

- `GET /broadcasts`
- `GET /broadcasts/{broadcast_id}`
- `GET /broadcasts/{broadcast_id}/notifications`

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
