### PR TITLE
spec: remove beta flag from imports endpoints

### DIFF
--- a/.changeset/pretty-chairs-fly.md
+++ b/.changeset/pretty-chairs-fly.md
@@ -1,0 +1,8 @@
+---
+"openapi": minor
+---
+
+Remove the beta flags from the import apis. This includes:
+
+- `POST /imports`
+- `GET /imports/{import_id}`

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -2117,7 +2117,6 @@
     },
     "/imports": {
       "post": {
-        "x-beta": true,
         "operationId": "imports-create",
         "tags": ["Imports API"],
         "summary": "Create a import",
@@ -2218,7 +2217,6 @@
     },
     "/imports/{import_id}": {
       "get": {
-        "x-beta": true,
         "operationId": "imports-get",
         "tags": ["Imports API"],
         "summary": "Get the status of an import",


### PR DESCRIPTION
## Change description

Remove the beta flags from the import apis. This includes:

- `POST /imports`
- `GET /imports/{import_id}`

## Type of change

- [x] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
