### PR TITLE
spec: remove beta flag from users push-subscriptions endpoints

### DIFF
--- a/.changeset/small-penguins-film.md
+++ b/.changeset/small-penguins-film.md
@@ -1,0 +1,8 @@
+---
+"openapi": minor
+---
+
+Remove the beta flags from the users push-subscriptions apis. This includes:
+
+- `GET /users/{user_id}/push_subscriptions`
+- `DELETE /users/{user_id}/push_subscriptions/{subscription_id}`

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -1513,7 +1513,6 @@
         "summary": "Fetch user's push subscriptions",
         "description": "Fetch a user's push subscriptions. Returns a paginated list of web and mobile push subscriptions for all platforms.",
         "operationId": "users-push-subscriptions-list",
-        "x-beta": true,
         "responses": {
           "200": {
             "description": "OK",
@@ -1556,7 +1555,6 @@
         "summary": "Delete user's push subscription",
         "description": "Delete a user's push subscriptions. Identifies the user by the user's ID and the push subscription by the subscription's ID. ",
         "operationId": "users-push-subscriptions-delete",
-        "x-beta": true,
         "responses": {
           "204": { "description": "Subscription delete successfully" },
           "404": { "description": "User or subscription not found" }


### PR DESCRIPTION
## Change description

Remove the beta flags from the users push-subscriptions apis. This includes:

- `GET /users/{user_id}/push_subscriptions`
- `DELETE /users/{user_id}/push_subscriptions/{subscription_id}`

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
