### PR TITLE
chore: accept custom server url

### DIFF
--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -16,6 +16,29 @@ dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 const specFile = argv.spec || process.env.INPUT_SPEC || 'spec/openapi.json';
 const serverUrl = argv.server || process.env.SERVER_URL;
 
+if (argv.help) {
+  console.log(
+    `
+    Usage: 
+      tsx scripts/smoke-test.ts [--spec <path>] [--server <url>] [--op <operation>]'
+    
+    Options:
+      --spec <path>     Path to OpenAPI spec file (default: 'spec/openapi.json')
+      --server <url>    URL of server to test (default: process.env.SERVER_URL)
+      --op <operation>  Test only the specified operation (default: test all operations)
+    
+    Examples:
+      tsx scripts/smoke-test.ts --spec spec/openapi.json
+      tsx scripts/smoke-test.ts --op users-list
+      tsx scripts/smoke-test.ts --op users-list --server http://api-review-url.example.com
+  `
+      .replace(/^ {4}/gm, '')
+      .trim() + '\n',
+  );
+
+  process.exit(0);
+}
+
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
 

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -14,6 +14,7 @@ import { setTimeout } from 'timers/promises';
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 const specFile = argv.spec || process.env.INPUT_SPEC || 'spec/openapi.json';
+const serverUrl = argv.server || process.env.SERVER_URL;
 
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
@@ -84,7 +85,7 @@ async function request(
   }
 
   const config: AxiosRequestConfig = {
-    baseURL: process.env.SERVER_URL,
+    baseURL: serverUrl,
     method,
     url: operation.path,
     validateStatus: () => true,
@@ -294,11 +295,11 @@ async function main() {
     throw new Error('Please set the API_KEY, API_SECRET and USER_EMAIL environment variables to run the smoke tests');
   }
 
-  if (!process.env.SERVER_URL) {
+  if (!serverUrl) {
     throw new Error('Please set the SERVER_URL environment variable to run the smoke tests');
   }
 
-  console.log(`Running smoke tests against ${process.env.SERVER_URL.split('.').join('_')}`);
+  console.log(`Running smoke tests against ${serverUrl.split('.').join('_')}`);
 
   const newNotificationIds = await Promise.all(
     Array.from({ length: CREATE_NOTIFICATIONS_COUNT }).map(() =>


### PR DESCRIPTION
## Change description

Added a `--server-url` flag to the smoke test, and a `--help` to make testing easier

```
❯ tsx scripts/smoke-test.ts --help

Usage: 
  tsx scripts/smoke-test.ts [--spec <path>] [--server <url>] [--op <operation>]'

Options:
  --spec <path>     Path to OpenAPI spec file (default: 'spec/openapi.json')
  --server <url>    URL of server to test (default: process.env.SERVER_URL)
  --op <operation>  Test only the specified operation (default: test all operations)

Examples:
  tsx scripts/smoke-test.ts --spec spec/openapi.json
  tsx scripts/smoke-test.ts --op users-list
  tsx scripts/smoke-test.ts --op users-list --server http://api-review-url.example.com
```

## Type of change

- [x] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
