### PR TITLE
feat: add resource summaries

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -17,4 +17,5 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Download deps
-      uses: bahmutov/npm-install@v1
+      uses: u0reo/npm-install@fix/restore-failure
+#     uses: bahmutov/npm-install@v1

--- a/docs/lib/openapi.ts
+++ b/docs/lib/openapi.ts
@@ -40,12 +40,14 @@ export function getApiLinks(spec: OpenAPIV3.Document) {
   return Object.keys(spec.paths).flatMap((pathName) => {
     const path = spec.paths[pathName as keyof typeof spec.paths] || {};
 
-    return Object.keys(path).map((method) => {
-      const { operationId, summary } = path[
-        method as keyof typeof path
-      ] as OpenAPIV3.OperationObject;
+    return Object.keys(path)
+      .map((method) => {
+        const { operationId, summary } = path[
+          method as keyof typeof path
+        ] as OpenAPIV3.OperationObject;
 
-      return { path: pathName, method, operationId, summary };
-    });
+        return { path: pathName, method, operationId, summary };
+      })
+      .filter((x) => x.operationId);
   });
 }

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -62,6 +62,7 @@ function getOperations(document: OpenAPIV3.Document) {
   for (const path of Object.keys(document.paths)) {
     for (const method of Object.keys(document.paths[path])) {
       const operation = document.paths[path][method] as OpenAPIV3.OperationObject;
+      if (!operation.operationId) continue;
       methods.push(Object.assign(operation, { path, method }));
     }
   }

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -345,7 +345,7 @@ async function main() {
         operations.find((x) => x.operationId === 'broadcasts-list'),
         'authenticated',
         { per_page: 50 },
-      ).then((x) => x.data.broadcasts.filter((x) => x.status !== 'enqueued').map((x) => x.id));
+      ).then((x) => (x.data.broadcasts || []).filter((x) => x.status !== 'enqueued').map((x) => x.id));
     }
 
     let broadcastsReady = false;
@@ -362,7 +362,7 @@ async function main() {
         operations.find((x) => x.operationId === 'notifications-list'),
         'authenticated',
         { per_page: 50 },
-      ).then((x) => x.data.notifications.map((x) => x.id));
+      ).then((x) => (x.data.notifications || []).map((x) => x.id));
     }
 
     // end the loop when we have enough notifications

--- a/openapi/spec/openapi.json
+++ b/openapi/spec/openapi.json
@@ -9,6 +9,7 @@
   ],
   "paths": {
     "/broadcasts": {
+      "summary": "Manage notification broadcasts",
       "get": {
         "tags": ["Notification Broadcasts APIs"],
         "operationId": "broadcasts-list",
@@ -143,6 +144,7 @@
       }
     },
     "/notifications": {
+      "summary": "Manage user notifications",
       "post": {
         "operationId": "notifications-create",
         "tags": ["Notification Send API", "real-time"],
@@ -706,6 +708,7 @@
       }
     },
     "/users": {
+      "summary": "Manage users",
       "post": {
         "operationId": "users-create",
         "tags": ["Users APIs"],
@@ -1388,6 +1391,7 @@
       }
     },
     "/push_subscriptions": {
+      "summary": "Manage user push subscriptions",
       "post": {
         "tags": ["Subscription to push notifications APIs"],
         "summary": "Register a device token for a user",
@@ -1619,6 +1623,7 @@
       }
     },
     "/notification_preferences": {
+      "summary": "Manage user notification preferences",
       "get": {
         "parameters": [
           { "$ref": "#/components/parameters/x_magicbell_api_key_header" },
@@ -1789,6 +1794,7 @@
       }
     },
     "/subscriptions": {
+      "summary": "Manage user subscriptions",
       "get": {
         "operationId": "subscriptions-list",
         "tags": ["Subscription API"],
@@ -2171,6 +2177,7 @@
       }
     },
     "/imports": {
+      "summary": "Manage imports",
       "post": {
         "operationId": "imports-create",
         "tags": ["Imports API"],
@@ -2351,6 +2358,7 @@
       }
     },
     "/metrics": {
+      "summary": "Manage metrics",
       "get": {
         "operationId": "metrics-get",
         "tags": ["Metrics API"],


### PR DESCRIPTION
## Change description

Adds summaries to resources. These summaries are part of the OpenAPI spec, and can then be used to decorate `magicbell --help`

Also adds a validation to the spec validator that check if all root paths, such as `/broadcasts` and `/notifications` have a summary defined.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
