### PR TITLE
chore: don't include body for options requests

### DIFF
--- a/.github/actions/smoke-test/dist/index.js
+++ b/.github/actions/smoke-test/dist/index.js
@@ -83972,12 +83972,6 @@ async function request(operation, type, params = {}) {
     if (isPublicApi(operation)) {
         headers['origin'] = 'https://magicbell-smoke-test.example.com';
     }
-    if (type === 'preflight') {
-        headers['access-control-request-method'] = operation.method;
-        headers['access-control-request-headers'] =
-            'content-type, origin, x-magicbell-api-key, x-magicbell-user-email, x-magicbell-user-hmac';
-        headers['origin'] = 'https://magicbell-smoke-test.example.com';
-    }
     const config = {
         baseURL: serverUrl,
         method,
@@ -83992,6 +83986,13 @@ async function request(operation, type, params = {}) {
         },
         params,
     };
+    if (type === 'preflight') {
+        config.headers['access-control-request-method'] = operation.method;
+        config.headers['access-control-request-headers'] =
+            'content-type, origin, x-magicbell-api-key, x-magicbell-user-email, x-magicbell-user-hmac';
+        config.headers['origin'] = 'https://magicbell-smoke-test.example.com';
+        delete config.data;
+    }
     const response = await axios_default().request(config).catch((e) => {
         console.log(`ERROR: request ${config.method} ${config.url} resulted in a network error:`, {
             error: { type: e.constructor.name, name: e.name, message: e.message },

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -101,13 +101,6 @@ async function request(
     headers['origin'] = 'https://magicbell-smoke-test.example.com';
   }
 
-  if (type === 'preflight') {
-    headers['access-control-request-method'] = operation.method;
-    headers['access-control-request-headers'] =
-      'content-type, origin, x-magicbell-api-key, x-magicbell-user-email, x-magicbell-user-hmac';
-    headers['origin'] = 'https://magicbell-smoke-test.example.com';
-  }
-
   const config: AxiosRequestConfig = {
     baseURL: serverUrl,
     method,
@@ -122,6 +115,14 @@ async function request(
     },
     params,
   };
+
+  if (type === 'preflight') {
+    config.headers['access-control-request-method'] = operation.method;
+    config.headers['access-control-request-headers'] =
+      'content-type, origin, x-magicbell-api-key, x-magicbell-user-email, x-magicbell-user-hmac';
+    config.headers['origin'] = 'https://magicbell-smoke-test.example.com';
+    delete config.data;
+  }
 
   const response = await axios.request(config).catch((e) => {
     console.log(`ERROR: request ${config.method} ${config.url} resulted in a network error:`, {


### PR DESCRIPTION
## Change description

Don't include a body when making OPTIONS requests. AWS lambdas don't like it, and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS) says it shouldn't be there anyways.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
