### PR TITLE
chore: log curl request for failed smoke tests

### DIFF
--- a/.github/actions/smoke-test/dist/index.js
+++ b/.github/actions/smoke-test/dist/index.js
@@ -83950,12 +83950,23 @@ function getOperations(document) {
     }
     return methods;
 }
+const headerMaskMap = {
+    'X-MAGICBELL-API-KEY': '$MAGICBELL_API_KEY',
+    'X-MAGICBELL-API-SECRET': '$MAGICBELL_API_SECRET',
+    'X-MAGICBELL-USER-EMAIL': '$MAGICBELL_USER_EMAIL',
+    'X-MAGICBELL-USER-EXTERNAL-ID': '$MAGICBELL_USER_EXTERNAL_ID',
+    'X-MAGICBELL-USER-HMAC': '$MAGICBELL_USER_HMAC',
+};
 function toCurl({ method, baseURL, url, data, headers }) {
     return [
         `curl -X ${method.toUpperCase()}`,
         `${baseURL}/${url.replace(/^\//, '')}`,
         Object.entries(headers)
-            .map(([key, value]) => `-H '${key}: ${value}'`)
+            .map(([key, value]) => {
+            // only replace the value with an env key if the header has a value, otherwise we can't debug missing headers.
+            value = value ? headerMaskMap[key.toUpperCase()] || value : value;
+            return `-H "${key}: ${value}"`;
+        })
             .join(' '),
         data && `-d '${JSON.stringify(data)}'`,
     ].join(' ');

--- a/.github/actions/smoke-test/dist/index.js
+++ b/.github/actions/smoke-test/dist/index.js
@@ -84003,7 +84003,7 @@ async function request(operation, type, params = {}) {
     });
     const duration = Date.now() - start;
     const error = response.data?.errors?.[0]?.message;
-    return Object.assign(response, { duration, config: config, error });
+    return Object.assign(response, { duration, config, error });
 }
 function getByJsonPointer(obj, path) {
     return path
@@ -84069,16 +84069,18 @@ function createTests(operations) {
         list.parentTask = suites.tasks[suites.tasks.length - 1];
         list.add({
             title: 'HTTP 401: request without authentication headers return 401 unauthorized',
-            task: async () => {
+            task: async function () {
                 const res = await request(operation, 'no-headers');
+                this.requestConfig = res.config;
                 expect(res.status, res.error).equal(401);
                 expect(res.duration).lessThan(5000);
             },
         });
         list.add({
             title: 'HTTP 401: request with invalid auth headers returns 401 unauthorized',
-            task: async () => {
+            task: async function () {
                 const res = await request(operation, 'invalid-auth');
+                this.requestConfig = res.config;
                 expect(res.status, res.error).equal(401);
                 expect(res.duration).lessThan(5000);
             },
@@ -84095,9 +84097,10 @@ function createTests(operations) {
         list.add({
             title: `HTTP ${code}: request with valid api key and payload returns expected response`,
             skip: () => shouldSkip,
-            task: async () => {
+            task: async function () {
                 operation.path = getUrl(path);
                 const res = await request(operation, 'authenticated');
+                this.requestConfig = res.config;
                 expect(res.status, res.error).equal(code);
                 expect(res.duration).lessThan(5000);
                 if (isPublicApi(operation)) {
@@ -84128,9 +84131,10 @@ function createTests(operations) {
             list.add({
                 title: `HTTP 200: options request returns cors headers`,
                 skip: () => shouldSkip,
-                task: async () => {
+                task: async function () {
                     operation.path = getUrl(path);
                     const res = await request(operation, 'preflight');
+                    this.requestConfig = res.config;
                     expect(res.status, res.error).equal(200);
                     expect(res.duration).lessThan(5000);
                     // check cors headers
@@ -84212,6 +84216,9 @@ async function smoke_test_main() {
         console.log(`${chalk.red('✖')} ${err.task.listr.parentTask.title}`);
         console.log(`  ${chalk.red('✖')} ${err.task.title}`);
         console.log(`    error: ${err.message}`);
+        if ('requestConfig' in err.task) {
+            console.log(`    request: ${toCurl(err.task.requestConfig)}`);
+        }
     }
     process.exit(1);
 }

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -70,12 +70,24 @@ function getOperations(document: OpenAPIV3.Document) {
   return methods;
 }
 
+const headerMaskMap = {
+  'X-MAGICBELL-API-KEY': '$MAGICBELL_API_KEY',
+  'X-MAGICBELL-API-SECRET': '$MAGICBELL_API_SECRET',
+  'X-MAGICBELL-USER-EMAIL': '$MAGICBELL_USER_EMAIL',
+  'X-MAGICBELL-USER-EXTERNAL-ID': '$MAGICBELL_USER_EXTERNAL_ID',
+  'X-MAGICBELL-USER-HMAC': '$MAGICBELL_USER_HMAC',
+};
+
 function toCurl({ method, baseURL, url, data, headers }: AxiosRequestConfig) {
   return [
     `curl -X ${method.toUpperCase()}`,
     `${baseURL}/${url.replace(/^\//, '')}`,
     Object.entries(headers)
-      .map(([key, value]) => `-H '${key}: ${value}'`)
+      .map(([key, value]) => {
+        // only replace the value with an env key if the header has a value, otherwise we can't debug missing headers.
+        value = value ? headerMaskMap[key.toUpperCase()] || value : value;
+        return `-H "${key}: ${value}"`;
+      })
       .join(' '),
     data && `-d '${JSON.stringify(data)}'`,
   ].join(' ');

--- a/openapi/scripts/smoke-test.ts
+++ b/openapi/scripts/smoke-test.ts
@@ -136,7 +136,7 @@ async function request(
   const duration = Date.now() - start;
   const error = response.data?.errors?.[0]?.message;
 
-  return Object.assign(response, { duration, config: config, error });
+  return Object.assign(response, { duration, config, error });
 }
 
 function getByJsonPointer(obj: Record<string, unknown>, path: string) {
@@ -217,8 +217,10 @@ function createTests(operations: Operation[]) {
 
     list.add({
       title: 'HTTP 401: request without authentication headers return 401 unauthorized',
-      task: async () => {
+      task: async function () {
         const res = await request(operation, 'no-headers');
+        this.requestConfig = res.config;
+
         expect(res.status, res.error).equal(401);
         expect(res.duration).lessThan(5000);
       },
@@ -226,8 +228,10 @@ function createTests(operations: Operation[]) {
 
     list.add({
       title: 'HTTP 401: request with invalid auth headers returns 401 unauthorized',
-      task: async () => {
+      task: async function () {
         const res = await request(operation, 'invalid-auth');
+        this.requestConfig = res.config;
+
         expect(res.status, res.error).equal(401);
         expect(res.duration).lessThan(5000);
       },
@@ -247,10 +251,12 @@ function createTests(operations: Operation[]) {
     list.add({
       title: `HTTP ${code}: request with valid api key and payload returns expected response`,
       skip: () => shouldSkip,
-      task: async () => {
+      task: async function () {
         operation.path = getUrl(path);
 
         const res = await request(operation, 'authenticated');
+        this.requestConfig = res.config;
+
         expect(res.status, res.error).equal(code);
         expect(res.duration).lessThan(5000);
 
@@ -290,9 +296,11 @@ function createTests(operations: Operation[]) {
       list.add({
         title: `HTTP 200: options request returns cors headers`,
         skip: () => shouldSkip,
-        task: async () => {
+        task: async function () {
           operation.path = getUrl(path);
           const res = await request(operation, 'preflight');
+          this.requestConfig = res.config;
+
           expect(res.status, res.error).equal(200);
           expect(res.duration).lessThan(5000);
 
@@ -412,6 +420,9 @@ async function main() {
     console.log(`${chalk.red('✖')} ${err.task.listr.parentTask.title}`);
     console.log(`  ${chalk.red('✖')} ${err.task.title}`);
     console.log(`    error: ${err.message}`);
+    if ('requestConfig' in err.task) {
+      console.log(`    request: ${toCurl(err.task.requestConfig)}`);
+    }
   }
 
   process.exit(1);


### PR DESCRIPTION
## Change description

This logs the CURL statement for failed smoke-tests, like:

```
Running smoke tests against https://api_magicbell_dev/
Broadcasts not ready yet, waiting 3 seconds before trying again.
⚠ POST /subscriptions (id: subscriptions-create)
  ✖ expected 1 to equal 2
  ✔ HTTP 401: request with invalid auth headers returns 401 unauthorized
  ✔ HTTP 200: request with valid api key and payload returns expected response
  ✔ HTTP 200: options request returns cors headers

---- Error Summary ----

✖ POST /subscriptions (id: subscriptions-create)
  ✖ HTTP 401: request without authentication headers return 401 unauthorized
    error: expected 1 to equal 2
    request: curl -X POST https://api.magicbell.dev/subscriptions -H 'content-type: application/json' -H 'accept: application/json' -H 'user-agent: magicbell-openapi-smoke-test' -H 'origin: https://magicbell-smoke-test.example.com/' -d '{"subscription":{"categories":[{"slug":"comments","reason":"watching-the-repo"}],"topic":"acme-inc.orders.1234"}}'
```

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
